### PR TITLE
Add unit tests for lead/lag n/default validation and NA typing

### DIFF
--- a/tests/testthat/test-lead_and_lag.R
+++ b/tests/testthat/test-lead_and_lag.R
@@ -53,6 +53,15 @@ test_that("`lead()` / `lag()` validate `n`", {
   })
 })
 
+test_that("`lead()` / `lag()` reject non-numeric `n`", {
+  expect_snapshot(error = TRUE, {
+    lead(1:5, n = "1")
+  })
+  expect_snapshot(error = TRUE, {
+    lag(1:5, n = "1")
+  })
+})
+
 test_that("`lead()` / `lag()` check for empty dots", {
   expect_snapshot(error = TRUE, {
     lead(1:5, deault = 1)
@@ -131,6 +140,25 @@ test_that("`default` is cast to the type of `x`", {
   expect_snapshot(error = TRUE, {
     lead(1L, default = 1.5)
   })
+})
+
+test_that("`lead()` / `lag()` require scalar `default`", {
+  expect_snapshot(error = TRUE, {
+    lead(1:5, default = 1:2)
+  })
+  expect_snapshot(error = TRUE, {
+    lag(1:5, default = 1:2)
+  })
+})
+
+
+test_that("`default = NA` is typed to match `x`", {
+  expect_identical(typeof(lag(1L, default = NA)), "integer")
+  expect_identical(typeof(lead(1L, default = NA)), "integer")
+
+  x_date <- as.Date("2020-01-01") + 0:2
+  expect_s3_class(lag(x_date, default = NA), "Date")
+  expect_s3_class(lead(x_date, default = NA), "Date")
 })
 
 test_that("`default` must be size 1 (#5641)", {


### PR DESCRIPTION
### Motivation
- Exercise and lock down error paths in `lead()` / `lag()` for invalid `n` values so the `if(!is.numeric(n))` validation is covered.
- Ensure scalar-length validation for `default` is tested so the `stop("`default` must be NULL or a scalar value...")` branch is covered.
- Verify the `default = NA` behavior produces a typed NA that matches the input `x` and thus covers `pick_correct_na_to_match_type(x)`.

### Description
- Added tests in `tests/testthat/test-lead_and_lag.R` to assert `lead()` / `lag()` reject non-numeric `n` using `expect_snapshot(error = TRUE)`.
- Added tests in `tests/testthat/test-lead_and_lag.R` to assert `lead()` / `lag()` error when `default` is not scalar using `expect_snapshot(error = TRUE)`.
- Added tests in `tests/testthat/test-lead_and_lag.R` to assert `default = NA` yields typed NA for integer vectors and preserves `Date` class using `expect_identical()` and `expect_s3_class()`.
- All new tests use the existing `test-lead_and_lag.R` harness and snapshot-style error assertions to capture message output.

### Testing
- Attempted to run `devtools::document()`, but the command could not execute because `R` is not available in the environment (failed: `R: command not found`).
- Attempted to run `devtools::test()`, but the command could not execute because `R` is not available in the environment (failed: `R: command not found`).
- Attempted to run `devtools::check()`, but the command could not execute because `R` is not available in the environment (failed: `R: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a14fc4680f88333b61ba10b2c4dec68)